### PR TITLE
refactor: output document bundle

### DIFF
--- a/.changeset/light-foxes-itch.md
+++ b/.changeset/light-foxes-itch.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-document": minor
+---
+
+BREAKING CHANGE: bundle src/Document before render html content, env variables follow internal vite

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# dist
+.vite-document

--- a/README.md
+++ b/README.md
@@ -4,13 +4,10 @@
 
 *use `Document.tsx` as html template.*
 
-> **⚠️ WARNING**  
-`production` or `development` flag on `import.meta.env` is not correct. Please use `import.meta.env.MODE` instead. If have any advice, please visit [#10](https://github.com/JiangWeixian/vite-plugin-document/issues/10)
-
 ## install
 
 ```console
-pnpm i vite-plugin-document
+pnpm i vite-plugin-document -D
 ```
 
 ## usage
@@ -53,11 +50,21 @@ export default Document
 
 check [playground](/playground/) for more details
 
-### options
+## options
 
-`documentFilepath` custom `Document.tsx` filepath, default is `root/src/Document.tsx`
+### `documentFilepath` 
+
+Custom `Document.tsx` filepath
 
 - type `string`
+- default `<rootDir>/src/Document.tsx`
+
+### `outDir`
+
+In build mode, `vite-plugin-document` will bundle `<rootDir>/src/Document.tsx` into disk
+
+- type `string`
+- default `<rootDir>/.vite-document`
 
 ## development
 

--- a/playground/src/Document.tsx
+++ b/playground/src/Document.tsx
@@ -7,7 +7,8 @@ const Document = () => {
       <head>
         <meta charSet="UTF-8" />
         <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
-        <meta name="keywords" content={import.meta.env.MODE === 'production' ? 'prod' : 'dev'} />
+        <meta name="env.mode" content={import.meta.env.MODE === 'production' ? 'prod' : 'dev'} />
+        <meta name="env.prod" content={import.meta.env.PROD ? 'prod' : 'dev'} />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>{`${title}`}</title>
       </head>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,7 +80,7 @@ importers:
       react-router-dom: ^6.4.2
       typescript: ^4.6.4
       vite: ^3.0.7
-      vite-plugin-document: workspace:^0.1.0
+      vite-plugin-document: workspace:^0.1.2
       vite-plugin-pages: ^0.26.0
     dependencies:
       react: 18.2.0


### PR DESCRIPTION
BREAKING CHANGE: use bundled document before render html, import.meta.env is follow
internal vite

Closes: #10<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
